### PR TITLE
use latest windows version directory

### DIFF
--- a/lib/consts.js
+++ b/lib/consts.js
@@ -11,8 +11,8 @@ const MAC_PATH = `/app.asar.unpacked/dist/ssb-interop.bundle.js`;
 const LINUX_PATH = `/app.asar.unpacked/dist/ssb-interop.bundle.js`;
 
 function getWindowsDirectory() {
-  for (let i = 0; i < 10; i++) {
-    for (let j = 0; j < 10; j++) {
+  for (let i = 9; i >= 0; --i) {
+    for (let j = 9; j >= 0; --j) {
       const ver = `4.${i}.${j}`;
       const dir = `${homeDir}\\AppData\\Local\\slack\\app-${ver}\\resources`;
       if (fs.existsSync(dir)) {


### PR DESCRIPTION
Slack may have multiple version directories installed if it has been updated. The latest version is the one in use.