### PR TITLE
feat: Add scoop compatibility

### DIFF
--- a/lib/consts.js
+++ b/lib/consts.js
@@ -13,23 +13,27 @@ const LINUX_PATH = `/app.asar.unpacked/dist/preload.bundle.js`;
 function getWindowsDirectory() {
   for (let i = 9; i >= 0; --i) {
     for (let j = 9; j >= 0; --j) {
+      const ver = `4.${i}.${j}`;
+
+      const dir = `${homeDir}\\AppData\\Local\\slack\\app-${ver}\\resources`;
+      if (fs.existsSync(dir)) {
+        return dir;
+      }
+
+      const globalScoopDir = `${process.env.ProgramData}\\scoop\\apps\\slack\\${ver}\\resources`;
+      if (fs.existsSync(globalScoopDir)) {
+        return globalScoopDir;
+      }
+
+      const localScoopDir = `${homeDir}\\scoop\\apps\\slack\\${ver}\\resources`;
+      if (fs.existsSync(localScoopDir)) {
+        return localScoopDir;
+      }
+
       for (let k = 9; k >= 0; --k) {
-        const ver = `4.${i}.${j}`;
-        const dir = `${homeDir}\\AppData\\Local\\slack\\app-${ver}\\resources`;
         const betaDir = `${homeDir}\\AppData\\Local\\slack\\app-${ver}-beta${k}\\resources`;
-        const globalScoopDir = `${process.env.ProgramData}\\scoop\\apps\\slack\\${ver}\\resources`;
-        const localScoopDir = `${homeDir}\\scoop\\apps\\slack\\${ver}\\resources`;
-        if (fs.existsSync(dir)) {
-          return dir;
-        }
-        else if (fs.existsSync(betaDir)) {
+        if (fs.existsSync(betaDir)) {
           return betaDir;
-        }
-        else if (fs.existsSync(globalScoopDir)) {
-          return globalScoopDir;
-        }
-        else if (fs.existsSync(localScoopDir)) {
-          return localScoopDir;
         }
       }
     }

--- a/lib/consts.js
+++ b/lib/consts.js
@@ -17,11 +17,19 @@ function getWindowsDirectory() {
         const ver = `4.${i}.${j}`;
         const dir = `${homeDir}\\AppData\\Local\\slack\\app-${ver}\\resources`;
         const betaDir = `${homeDir}\\AppData\\Local\\slack\\app-${ver}-beta${k}\\resources`;
+        const globalScoopDir = `${process.env.ProgramData}\\scoop\\apps\\slack\\${ver}\\resources`;
+        const localScoopDir = `${homeDir}\\scoop\\apps\\slack\\${ver}\\resources`;
         if (fs.existsSync(dir)) {
           return dir;
         }
         else if (fs.existsSync(betaDir)) {
           return betaDir;
+        }
+        else if (fs.existsSync(globalScoopDir)) {
+          return globalScoopDir;
+        }
+        else if (fs.existsSync(localScoopDir)) {
+          return localScoopDir;
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -55,9 +55,9 @@
     "configstore": "^5.0.0",
     "figlet": "^1.2.3",
     "inquirer": "^6.5.0",
+    "is-elevated": "^3.0.0",
     "is-root": "^2.1.0",
     "js-yaml": "^3.13.1",
-    "is-elevated": "^3.0.0",
     "minimist": "^1.2.0",
     "rimraf": "latest"
   },


### PR DESCRIPTION
mtslack will now be able to locate Slack even if it is installed via [Scoop](https://scoop.sh/)